### PR TITLE
COM-546: Fix photo library bugs — iCloud loading, spinners & album support

### DIFF
--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -35,15 +35,13 @@ open class AssetManager {
         ? PHAsset.fetchAssets(with: options)
         : PHAsset.fetchAssets(with: .image, options: options)
 
-      if fetchResult.count > 0 {
-        var assets = [PHAsset]()
-        fetchResult.enumerateObjects({ object, _, _ in
-          assets.insert(object, at: 0)
-        })
+      var assets = [PHAsset]()
+      fetchResult.enumerateObjects({ object, _, _ in
+        assets.insert(object, at: 0)
+      })
 
-        DispatchQueue.main.async {
-          completion(assets)
-        }
+      DispatchQueue.main.async {
+        completion(assets)
       }
     }
   }
@@ -61,6 +59,22 @@ open class AssetManager {
         completion(image)
       }
     }
+  }
+
+  @available(*, deprecated, renamed: "resolveAssets(_:completion:)")
+  public static func resolveAssets(_ assets: [PHAsset]) -> [Image] {
+    let imageManager = PHImageManager.default()
+    let requestOptions = PHImageRequestOptions()
+    requestOptions.isSynchronous = true
+
+    var images = [Image]()
+    for asset in assets {
+      imageManager.requestImageData(for: asset, options: requestOptions) { data, name, _, _ in
+        guard let data = data, let name = name else { return }
+        images.append(Image(data: data, name: name))
+      }
+    }
+    return images
   }
 
   public static func resolveAssets(_ assets: [PHAsset], completion: @escaping (_ images: [Image]) -> Void) {

--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -55,27 +55,37 @@ open class AssetManager {
     requestOptions.isNetworkAccessAllowed = true
 
     imageManager.requestImage(for: asset, targetSize: size, contentMode: .aspectFill, options: requestOptions) { image, info in
-      if let info = info, info["PHImageFileUTIKey"] == nil {
-        DispatchQueue.main.async(execute: {
-          completion(image)
-        })
+      let isDegraded = (info?[PHImageResultIsDegradedKey] as? Bool) == true
+      guard !isDegraded else { return }
+      DispatchQueue.main.async {
+        completion(image)
       }
     }
   }
- 
-  public static func resolveAssets(_ assets: [PHAsset]) -> [Image] {
+
+  public static func resolveAssets(_ assets: [PHAsset], completion: @escaping (_ images: [Image]) -> Void) {
     let imageManager = PHImageManager.default()
     let requestOptions = PHImageRequestOptions()
-    requestOptions.isSynchronous = true
+    requestOptions.isNetworkAccessAllowed = true
+    requestOptions.deliveryMode = .highQualityFormat
 
-    var images = [Image]()
-    for asset in assets {
+    let group = DispatchGroup()
+    var indexedImages = [(index: Int, image: Image)]()
+    let lock = NSLock()
+
+    for (index, asset) in assets.enumerated() {
+      group.enter()
       imageManager.requestImageData(for: asset, options: requestOptions) { data, name, _, _ in
-        guard let data else { return }
-        guard let name else { return }
-          images.append(Image(data: data, name: name))
+        defer { group.leave() }
+        guard let data = data, let name = name else { return }
+        lock.lock()
+        indexedImages.append((index, Image(data: data, name: name)))
+        lock.unlock()
       }
     }
-    return images
+
+    group.notify(queue: .main) {
+      completion(indexedImages.sorted { $0.index < $1.index }.map { $0.image })
+    }
   }
 }

--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -25,7 +25,10 @@ open class AssetManager {
   }
 
   public static func fetch(withConfiguration configuration: ImagePickerConfiguration, _ completion: @escaping (_ assets: [PHAsset]) -> Void) {
-    guard PHPhotoLibrary.authorizationStatus() == .authorized else { return }
+    guard PHPhotoLibrary.authorizationStatus() == .authorized else {
+      DispatchQueue.main.async { completion([]) }
+      return
+    }
 
     let options = PHFetchOptions()
     options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]

--- a/Source/CameraView/CameraMan.swift
+++ b/Source/CameraView/CameraMan.swift
@@ -20,6 +20,7 @@ class CameraMan {
   var stillImageOutput: AVCaptureStillImageOutput?
   var startOnFrontCamera: Bool = false
   var photoQuality: AVCaptureSession.Preset = .photo
+  var photoAlbumName: String? = nil
 
   deinit {
     stop()
@@ -174,15 +175,24 @@ class CameraMan {
   }
 
   func savePhoto(_ image: UIImage, location: CLLocation?, completion: (() -> Void)? = nil) {
-    PHPhotoLibrary.shared().performChanges({
-      let request = PHAssetChangeRequest.creationRequestForAsset(from: image)
-      request.creationDate = Date()
-      request.location = location
-      }, completionHandler: { (_, _) in
-        DispatchQueue.main.async {
-          completion?()
+    let saveBlock: (PHAssetCollection?) -> Void = { collection in
+      PHPhotoLibrary.shared().performChanges({
+        let request = PHAssetChangeRequest.creationRequestForAsset(from: image)
+        request.creationDate = Date()
+        request.location = location
+        if let collection = collection, let placeholder = request.placeholderForCreatedAsset {
+          PHAssetCollectionChangeRequest(for: collection)?.addAssets([placeholder] as NSArray)
         }
-    })
+      }, completionHandler: { _, _ in
+        DispatchQueue.main.async { completion?() }
+      })
+    }
+
+    if let albumName = photoAlbumName {
+      getOrCreateAlbum(named: albumName) { saveBlock($0) }
+    } else {
+      saveBlock(nil)
+    }
   }
 
   private func attachEXIF(to image: Data, exif: [String: Any]) -> Data? {
@@ -259,50 +269,62 @@ class CameraMan {
 
   func savePhoto(_ image: Data, location: CLLocation?, heading: CLHeading?, completion: (() -> Void)? = nil) {
 
-    func complite() {
-      DispatchQueue.main.async {
-        completion?()
-      }
+    func complete() {
+      DispatchQueue.main.async { completion?() }
     }
 
     let path = NSTemporaryDirectory() + "file-\(arc4random()).jpg"
     let url = URL(fileURLWithPath: path)
-    guard let imageSource = CGImageSourceCreateWithData(image as CFData, nil) else {
-      complite()
-      return
-    }
-    guard var properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [String: Any] else {
-     complite()
-     return
-    }
+    guard let imageSource = CGImageSourceCreateWithData(image as CFData, nil) else { complete(); return }
+    guard var properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [String: Any] else { complete(); return }
     if let location = location {
-        properties[kCGImagePropertyGPSDictionary as String] = self.getGPSDictionary(for: location, and: heading)
+      properties[kCGImagePropertyGPSDictionary as String] = self.getGPSDictionary(for: location, and: heading)
     }
-    guard let data = self.attachEXIF(to: image, exif: properties) else {
-      complite()
+    guard let data = self.attachEXIF(to: image, exif: properties) else { complete(); return }
+
+    let saveBlock: (PHAssetCollection?) -> Void = { collection in
+      PHPhotoLibrary.shared().performChanges({
+        let request: PHAssetChangeRequest?
+        do {
+          try data.write(to: url)
+          request = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: url)
+        } catch {
+          request = UIImage(data: image).flatMap {
+            PHAssetChangeRequest.creationRequestForAsset(from: $0)
+          }
+        }
+        guard let _request = request else { return }
+        _request.creationDate = Date()
+        _request.location = location
+        if let collection = collection, let placeholder = _request.placeholderForCreatedAsset {
+          PHAssetCollectionChangeRequest(for: collection)?.addAssets([placeholder] as NSArray)
+        }
+      }, completionHandler: { _, _ in complete() })
+    }
+
+    if let albumName = photoAlbumName {
+      getOrCreateAlbum(named: albumName) { saveBlock($0) }
+    } else {
+      saveBlock(nil)
+    }
+  }
+
+  private func getOrCreateAlbum(named name: String, completion: @escaping (PHAssetCollection?) -> Void) {
+    let fetchOptions = PHFetchOptions()
+    fetchOptions.predicate = NSPredicate(format: "title = %@", name)
+    let existing = PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumRegular, options: fetchOptions)
+    if let collection = existing.firstObject {
+      completion(collection)
       return
     }
-
+    var placeholder: PHObjectPlaceholder?
     PHPhotoLibrary.shared().performChanges({
-      let request: PHAssetChangeRequest?
-      do {
-        try data.write(to: url)
-        request = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: url)
-      } catch {
-        request = UIImage(data: image).flatMap {
-          PHAssetChangeRequest.creationRequestForAsset(from: $0)
-        }
-      }
-
-      guard let _request = request else {
-        complite()
-        return
-      }
-
-      _request.creationDate = Date()
-      _request.location = location
-    }, completionHandler: { (_, _) in
-      complite()
+      let request = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: name)
+      placeholder = request.placeholderForCreatedAssetCollection
+    }, completionHandler: { success, _ in
+      guard success, let id = placeholder?.localIdentifier else { completion(nil); return }
+      let collection = PHAssetCollection.fetchAssetCollections(withLocalIdentifiers: [id], options: nil).firstObject
+      completion(collection)
     })
   }
 

--- a/Source/CameraView/CameraView.swift
+++ b/Source/CameraView/CameraView.swift
@@ -136,6 +136,7 @@ class CameraView: UIViewController, CLLocationManagerDelegate, CameraManDelegate
     }
 
     cameraMan.delegate = self
+    cameraMan.photoAlbumName = configuration.photoAlbumName
     cameraMan.setup(self.startOnFrontCamera, photoQuality: self.configuration.photoQuality)
   }
 

--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -55,6 +55,7 @@ import UIKit
   @objc public var useLowResolutionPreviewImage = false
   @objc public var photoQuality: AVCaptureSession.Preset = .high
   @objc public var galleryOnly = false
+  @objc public var photoAlbumName: String? = nil
 
   // MARK: Images
   @objc public var indicatorView: UIView = {

--- a/Source/ImageGallery/ImageGalleryView.swift
+++ b/Source/ImageGallery/ImageGalleryView.swift
@@ -80,6 +80,19 @@ open class ImageGalleryView: UIView {
 
   open lazy var selectedStack = ImageStack()
   lazy var assets = [PHAsset]()
+  var isLoading = true
+
+  lazy var loadingIndicator: UIActivityIndicatorView = {
+    let style: UIActivityIndicatorView.Style
+    if #available(iOS 13.0, *) {
+      style = .medium
+    } else {
+      style = .gray
+    }
+    let indicator = UIActivityIndicatorView(style: style)
+    indicator.color = configuration.noImagesColor
+    return indicator
+  }()
 
   weak var delegate: ImageGalleryPanGestureDelegate?
   var collectionSize: CGSize?
@@ -121,6 +134,8 @@ open class ImageGalleryView: UIView {
 
     topSeparator.addSubview(configuration.indicatorView)
 
+    addSubview(loadingIndicator)
+
     imagesBeforeLoading = 0
     fetchPhotos()
   }
@@ -154,6 +169,7 @@ open class ImageGalleryView: UIView {
     }
     
     noImagesLabel.center = CGPoint(x: bounds.width / 2, y: (bounds.height + Dimensions.galleryBarHeight) / 2)
+    loadingIndicator.center = noImagesLabel.center
 
     collectionView.reloadData()
   }
@@ -175,7 +191,11 @@ open class ImageGalleryView: UIView {
   // MARK: - Photos handler
 
   func fetchPhotos(_ completion: (() -> Void)? = nil) {
+    isLoading = true
+    loadingIndicator.startAnimating()
     AssetManager.fetch(withConfiguration: configuration) { assets in
+      self.isLoading = false
+      self.loadingIndicator.stopAnimating()
       self.assets.removeAll()
       self.assets.append(contentsOf: assets)
       self.collectionView.reloadData()
@@ -204,7 +224,7 @@ open class ImageGalleryView: UIView {
   }
 
   func displayNoImagesMessage(_ hideCollectionView: Bool) {
-    collectionView.alpha = hideCollectionView ? 0 : 1
+    collectionView.alpha = (hideCollectionView && !isLoading) ? 0 : 1
     updateNoImagesLabel()
   }
 }

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -391,8 +391,11 @@ extension ImagePickerController: BottomContainerViewDelegate {
   }
 
   func doneButtonDidPress() {
-    let images = AssetManager.resolveAssets(stack.assets)
-    delegate?.doneButtonDidPress(self, images: images)
+    setLoadingState(true)
+    AssetManager.resolveAssets(stack.assets) { images in
+      self.setLoadingState(false)
+      self.delegate?.doneButtonDidPress(self, images: images)
+    }
   }
 
   func cancelButtonDidPress() {
@@ -400,8 +403,34 @@ extension ImagePickerController: BottomContainerViewDelegate {
   }
 
   func imageStackViewDidPress() {
-    let images = AssetManager.resolveAssets(stack.assets)
-    delegate?.wrapperDidPress(self, images: images)
+    setLoadingState(true)
+    AssetManager.resolveAssets(stack.assets) { images in
+      self.setLoadingState(false)
+      self.delegate?.wrapperDidPress(self, images: images)
+    }
+  }
+
+  private func setLoadingState(_ loading: Bool) {
+    bottomContainer.doneButton.isHidden = loading
+    bottomContainer.tapGestureRecognizer.isEnabled = !loading
+    if loading {
+      let style: UIActivityIndicatorView.Style
+      if #available(iOS 13.0, *) {
+        style = .medium
+      } else {
+        style = .white
+      }
+      let indicator = UIActivityIndicatorView(style: style)
+      indicator.color = .white
+      indicator.tag = 999
+      indicator.translatesAutoresizingMaskIntoConstraints = false
+      bottomContainer.addSubview(indicator)
+      bottomContainer.addConstraint(NSLayoutConstraint(item: indicator, attribute: .centerX, relatedBy: .equal, toItem: bottomContainer.doneButton, attribute: .centerX, multiplier: 1, constant: 0))
+      bottomContainer.addConstraint(NSLayoutConstraint(item: indicator, attribute: .centerY, relatedBy: .equal, toItem: bottomContainer.doneButton, attribute: .centerY, multiplier: 1, constant: 0))
+      indicator.startAnimating()
+    } else {
+      bottomContainer.subviews.first(where: { $0.tag == 999 })?.removeFromSuperview()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **iCloud support**: enabled network access when loading photos so assets stored in iCloud download correctly instead of failing silently
- **Loading spinners**: added activity indicators while fetching the photo library and while resolving selected assets before calling the delegate
- **Album support**: added `photoAlbumName` option to `Configuration` — when set, all captured photos are saved into the specified album (created automatically if it doesn't exist); falls back to Camera Roll if left `nil`
- **Empty library fix**: `fetch()` completion was never called when the photo library was empty, leaving the spinner running forever and the empty-state label not appearing
- **Unauthorized access fix**: `fetch()` returned early without calling completion on denied/restricted status, leaving the spinner hanging indefinitely

## Changes

| File | Change |
|------|--------|
| `AssetManager.swift` | Made `resolveAssets` async with `DispatchGroup`; enabled iCloud downloads; fixed degraded-image skip logic; fixed `fetch()` not calling completion on empty library or unauthorized status |
| `ImageGalleryView.swift` | Added spinner while fetching photos from library; fixed empty-state visibility during loading |
| `ImagePickerController.swift` | Added loading state (spinner + disabled controls) while resolving selected assets |
| `Configuration.swift` | Added `photoAlbumName: String?` option (default `nil`) |
| `CameraView.swift` | Passes `photoAlbumName` from config to `CameraMan` |
| `CameraMan.swift` | Saves photos to named album via `PHAssetCollectionChangeRequest`; creates album if missing; graceful fallback to Camera Roll |

## Backward compatibility

All changes are fully backward compatible — default values preserve existing behaviour for users who don't set `photoAlbumName`.

## Usage

```swift
let config = ImagePickerConfiguration()
config.photoAlbumName = "Cropwise"
```